### PR TITLE
Add id, created timestamp, and label to JSON response for bulk tests

### DIFF
--- a/www/resultBatch.inc
+++ b/www/resultBatch.inc
@@ -89,6 +89,9 @@ $page_description = "Bulk website performance test result$testLabel.";
 
 if($json)
 {
+  $json_response['id'] = $test['test']['id'];
+  $json_response['created'] = $test['testinfo']['created'];
+  $json_response['label'] = $test['testinfo']['label'];
   $json_response['tests'] = $testIds;
   json_response($json_response);
 }


### PR DESCRIPTION
Hey @pmeenan… Thanks for changing the JSON response for build tests to being the list of test ids.

Would also like to add these few fields too

I've tested it locally and everything seems ok but happy revise if needed