### PR TITLE
Fix EC2 instance lifecycle

### DIFF
--- a/www/ec2/ec2.inc.php
+++ b/www/ec2/ec2.inc.php
@@ -207,7 +207,7 @@ function EC2_TerminateIdleInstances() {
                   $lastWork = $tester['last'];
                 if (isset($tester['elapsed']) && $tester['elapsed'] < $lastCheck)
                   $lastCheck = $tester['elapsed'];
-                if (isset($tester['test']) && strlen($tester['test'])) {
+                if (!isset($tester['offline']) || !$tester['offline']) {
                   // don't terminate an instance that is busy with a test
                   $terminate = false;
                 }
@@ -297,7 +297,7 @@ function EC2_SendInstancesOffline() {
     // See if we have any online testers that we need to make offline
     $online_target = max($info['min'], intval($locations[$ami]['tests'] / ($scaleFactor / 2)));
     foreach ($info['locations'] as $location) {
-      $testers = GetTesters($location);
+      $testers = GetTesters($location, true);
       if (isset($testers) && is_array($testers) && isset($testers['testers']) && count($testers['testers'])) {
         $online = 0;
         foreach ($testers['testers'] as $tester) {
@@ -374,7 +374,7 @@ function EC2_StartNeededInstances() {
       // See if we have any offline testers that we need to bring online
       $online_target = max($target, intval($locations[$ami]['tests'] / ($scaleFactor / 2)));
       foreach ($info['locations'] as $location) {
-        $testers = GetTesters($location);
+        $testers = GetTesters($location, true);
         if (isset($testers) && is_array($testers) && isset($testers['testers']) && count($testers['testers'])) {
           $online = 0;
           foreach ($testers['testers'] as $tester) {

--- a/www/getTesters.php
+++ b/www/getTesters.php
@@ -55,6 +55,7 @@ if( array_key_exists('f', $_REQUEST) && $_REQUEST['f'] == 'json' ) {
       echo "<tr><th class=\"tester\">Tester</th><th>Busy?</th><th>Last Check (minutes)</th><th>Last Work (minutes)</th><th>Version</th><th>PC</th><th>EC2 Instance</th><th>CPU Utilization</th><th>Error Rate</th><th>Free Disk (GB)</th><th>uptime (minutes)</th><th>Screen Size</th>";
       echo "<th>IP</th><th>DNS Server(s)</th>";
       if ($admin) {
+        echo "<th>Flag as offline</th>";
         echo "<th>Current Test</th>";
       }
       echo "</tr>\n";
@@ -91,6 +92,7 @@ if( array_key_exists('f', $_REQUEST) && $_REQUEST['f'] == 'json' ) {
         echo "<td nowrap>" . @htmlspecialchars($tester['ip']) . "</td>";
         echo "<td nowrap>" . @htmlspecialchars($tester['dns']) . "</td>";
         if ($admin) {
+          echo "<td nowrap>" . @htmlspecialchars($tester['offline']) . "</td>";
           echo "<td nowrap>" . @htmlspecialchars($tester['test']) . "</td>";
         }
         echo "</tr>";

--- a/www/work/getwork.php
+++ b/www/work/getwork.php
@@ -164,9 +164,10 @@ function GetTesterIndex($locInfo, &$testerIndex, &$testerCount, &$offline) {
       if (strlen($ec2)) {
         foreach($testers['testers'] as $index => $testerInfo) {
           if (isset($testerInfo['ec2']) && $testerInfo['ec2'] == $ec2 &&
-              isset($testerInfo['offline']) && $testerInfo['offline'])
+              isset($testerInfo['offline']) && $testerInfo['offline']) {
             $offline = true;
             break;
+          }
         }
       }
       foreach($testers['testers'] as $index => $testerInfo)
@@ -373,31 +374,30 @@ function GetJob() {
           $ok = true;
         }
       }
-
-      // keep track of the last time this location reported in
-      $testerInfo = array();
-      $testerInfo['ip'] = $_SERVER['REMOTE_ADDR'];
-      $testerInfo['pc'] = $pc;
-      $testerInfo['ec2'] = $ec2;
-      $testerInfo['ver'] = array_key_exists('version', $_GET) ? $_GET['version'] : $_GET['ver'];
-      $testerInfo['freedisk'] = @$_GET['freedisk'];
-      $testerInfo['upminutes'] = @$_GET['upminutes'];
-      $testerInfo['ie'] = @$_GET['ie'];
-      $testerInfo['dns'] = $dnsServers;
-      $testerInfo['video'] = @$_GET['video'];
-      $testerInfo['GPU'] = @$_GET['GPU'];
-      $testerInfo['screenwidth'] = $screenwidth;
-      $testerInfo['screenheight'] = $screenheight;
-      $testerInfo['winver'] = $winver;
-      $testerInfo['isWinServer'] = $isWinServer;
-      $testerInfo['isWin64'] = $isWin64;
-      $testerInfo['test'] = '';
-      if (isset($browsers) && count(array_filter($browsers, 'strlen')))
-        $testerInfo['browsers'] = $browsers;
-      if (isset($testId))
-        $testerInfo['test'] = $testId;
-      UpdateTester($location, $tester, $testerInfo);
     }
+    // keep track of the last time this location reported in
+    $testerInfo = array();
+    $testerInfo['ip'] = $_SERVER['REMOTE_ADDR'];
+    $testerInfo['pc'] = $pc;
+    $testerInfo['ec2'] = $ec2;
+    $testerInfo['ver'] = array_key_exists('version', $_GET) ? $_GET['version'] : $_GET['ver'];
+    $testerInfo['freedisk'] = @$_GET['freedisk'];
+    $testerInfo['upminutes'] = @$_GET['upminutes'];
+    $testerInfo['ie'] = @$_GET['ie'];
+    $testerInfo['dns'] = $dnsServers;
+    $testerInfo['video'] = @$_GET['video'];
+    $testerInfo['GPU'] = @$_GET['GPU'];
+    $testerInfo['screenwidth'] = $screenwidth;
+    $testerInfo['screenheight'] = $screenheight;
+    $testerInfo['winver'] = $winver;
+    $testerInfo['isWinServer'] = $isWinServer;
+    $testerInfo['isWin64'] = $isWin64;
+    $testerInfo['test'] = '';
+    if (isset($browsers) && count(array_filter($browsers, 'strlen')))
+      $testerInfo['browsers'] = $browsers;
+    if (isset($testId))
+      $testerInfo['test'] = $testId;
+    UpdateTester($location, $tester, $testerInfo);
   }
   
   return $is_done;

--- a/www/work/ping.php
+++ b/www/work/ping.php
@@ -61,7 +61,6 @@ foreach ($locations as $loc) {
         $testerInfo['winver'] = $winver;
         $testerInfo['isWinServer'] = $isWinServer;
         $testerInfo['isWin64'] = $isWin64;
-        $testerInfo['test'] = $testId;
         UpdateTester($location, $tester, $testerInfo, $cpu);
     }
 }


### PR DESCRIPTION
This commit ensures that EC2 instances are correctly set to offline before being shutdown.
I notice multiples bugs on this logic :
- EC2 instances flagged as offline was receiving tests (fix in getwork.php)
- Offline EC2 instances was not correctly reset to online when the server requires more machines (fix in ec2.inc.php on GetTesters call
- The server was terminated EC2 instances that was not offline.
- ping.php was wrongly resetting the « last work » timestamp and was blocking EC2 shutdown.