### PR TITLE
Add Opportunity and Experiment for images that are too large for display

### DIFF
--- a/www/experiments/common.inc
+++ b/www/experiments/common.inc
@@ -122,6 +122,7 @@ include __DIR__ . '/imgs-lazy-loaded.inc';
 include __DIR__ . '/imgs-lazy-loadable.inc';
 include __DIR__ . '/font-rendering.inc';
 include __DIR__ . '/fonts-3rdparty.inc';
+include __DIR__ . '/imgs-wasteful.inc';
 include __DIR__ . '/unused-preloads.inc';
 include __DIR__ . '/http-redirects.inc';
 

--- a/www/experiments/imgs-wasteful.inc
+++ b/www/experiments/imgs-wasteful.inc
@@ -1,0 +1,57 @@
+<?php
+
+$category = "Quick";
+$imgsTooLarge = $testStepResult->getMetric('imgs-too-large');
+
+function fullURL($url)
+{
+    global $requests;
+    if (preg_match('/^(https?\:\/\/)/', $url)) {
+        return $url;
+    } else {
+        return $requests[0]['url'] . $url;
+    }
+    return $url;
+}
+
+if (count($imgsTooLarge)) {
+    $tooLargeList = array();
+    $experimentSwapList = array();
+    foreach ($imgsTooLarge as $img) {
+        $srcToUse = "";
+
+        if ($img["currentSrc"]) {
+            $srcToUse .= $img["currentSrc"];
+        } elseif ($img["src"]) {
+            $srcToUse .= $img["src"];
+        }
+        $thisListItem = $srcToUse . " (Display: " . $img["displayWidth"] . "px wide, File: " . $img["naturalWidth"] . "px wide)";
+        $thisSwapItem = encodeURIComponent($srcToUse) . "|" . encodeURIComponent("{IMAGE_SERVICE_URL_HERE}/w_" . $img["displayWidth"] . "/" . fullURL($srcToUse));
+        array_push($tooLargeList, $thisListItem);
+        array_push($experimentSwapList, $thisSwapItem);
+    }
+
+    $assessment[$category]["opportunities"][] = array(
+        "title" =>  "Images are larger than necessary for display",
+        "desc" => "When images are much larger than they appear in the page, they increase download size without noticeably improving quality.",
+        "examples" => array_unique($tooLargeList),
+        "experiments" =>  array(
+            (object) [
+                "id" => '054',
+                'title' => 'See potential impact of using responsive images',
+                "desc" => "The broadly-supported <code>picture</code> element and/or the <code>srcset</code> and <code>sizes</code> attributes allow you to offer different file sizes to download for a given image depending on a variety of conditions. <a href=\"https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images\">Read more about Responsive Images on MDN </a>. This experiment replaces the image files at the sources below with images that are sized for display server-side.",
+                "expvar" => 'swap',
+                "expval" => array_unique($experimentSwapList)
+            ]
+        ),
+        "good" => false,
+        "hideassets" => true
+    );
+} else {
+    $assessment[$category]["opportunities"][] = array(
+        "title" => "Images are sized appropriately for display",
+        "desc" => "When images are much larger than they appear in the page, they increase download size without noticeably improving quality.",
+        "examples" => array(),
+        "good" => true
+    );
+}

--- a/www/experiments/imgs-wasteful.inc
+++ b/www/experiments/imgs-wasteful.inc
@@ -2,6 +2,7 @@
 
 $category = "Quick";
 $imgsTooLarge = $testStepResult->getMetric('imgs-too-large');
+$imgResizeURL = Util::getSetting('imgResizeURL', null);
 
 function fullURL($url)
 {
@@ -30,27 +31,42 @@ if (count($imgsTooLarge)) {
         array_push($tooLargeList, $thisListItem);
         array_push($experimentSwapList, $thisSwapItem);
     }
-
-    $assessment[$category]["opportunities"][] = array(
-        "title" =>  "Images are larger than necessary for display",
-        "desc" => "When images are much larger than they appear in the page, they increase download size without noticeably improving quality.",
-        "examples" => array_unique($tooLargeList),
-        "experiments" =>  array(
+    
+    $rwdImagesDesc = "The broadly-supported <code>picture</code> element and/or the <code>srcset</code> and <code>sizes</code> attributes allow you to offer different file sizes to download for a given image depending on a variety of conditions. <a href=\"https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images\">Read more about Responsive Images on MDN </a>.";
+    
+    $experimentsToAdd =  array(
+        (object) [
+            'title' => 'Consider implementing responsive image techniques',
+            "desc" => $rwdImgsDesc,
+            "expvar" => 'swap',
+            "expval" => array_unique($experimentSwapList)
+        ]
+    );
+        
+    if($imgResizeURL){
+        $experimentsToAdd = array(
             (object) [
                 "id" => '054',
                 'title' => 'See potential impact of using responsive images',
-                "desc" => "The broadly-supported <code>picture</code> element and/or the <code>srcset</code> and <code>sizes</code> attributes allow you to offer different file sizes to download for a given image depending on a variety of conditions. <a href=\"https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images\">Read more about Responsive Images on MDN </a>. This experiment replaces the image files at the sources below with images that are sized for display server-side.",
+                "desc" => "$rwdImagesDesc This experiment replaces the image files at the sources below with images that are sized for display server-side.",
                 "expvar" => 'swap',
                 "expval" => array_unique($experimentSwapList)
             ]
-        ),
+        );
+    }
+
+    $assessment[$category]["opportunities"][] = array(
+        "title" =>  "Images are larger than necessary for display",
+        "desc" => "When images are much larger than they appear in the page, they can increase page weight without noticeably improving quality.",
+        "examples" => array_unique($tooLargeList),
+        "experiments" => $experimentsToAdd,
         "good" => false,
         "hideassets" => true
     );
 } else {
     $assessment[$category]["opportunities"][] = array(
         "title" => "Images are sized appropriately for display",
-        "desc" => "When images are much larger than they appear in the page, they increase download size without noticeably improving quality.",
+        "desc" => "When images are much larger than they appear in the page, they can increase page weight without noticeably improving quality.",
         "examples" => array(),
         "good" => true
     );

--- a/www/experiments/imgs-wasteful.inc
+++ b/www/experiments/imgs-wasteful.inc
@@ -27,7 +27,7 @@ if (count($imgsTooLarge)) {
             $srcToUse .= $img["src"];
         }
         $thisListItem = $srcToUse . " (Display: " . $img["displayWidth"] . "px wide, File: " . $img["naturalWidth"] . "px wide)";
-        $thisSwapItem = encodeURIComponent($srcToUse) . "|" . encodeURIComponent("{IMAGE_SERVICE_URL_HERE}/w_" . $img["displayWidth"] . "/" . fullURL($srcToUse));
+        $thisSwapItem = encodeURIComponent($srcToUse) . "|" . encodeURIComponent("$imgResizeURL/w_" . $img["displayWidth"] . "/" . fullURL($srcToUse));
         array_push($tooLargeList, $thisListItem);
         array_push($experimentSwapList, $thisSwapItem);
     }

--- a/www/experiments/imgs-wasteful.inc
+++ b/www/experiments/imgs-wasteful.inc
@@ -27,7 +27,7 @@ if (count($imgsTooLarge)) {
             $srcToUse .= $img["src"];
         }
         $thisListItem = $srcToUse . " (Display: " . $img["displayWidth"] . "px wide, File: " . $img["naturalWidth"] . "px wide)";
-        $thisSwapItem = encodeURIComponent($srcToUse) . "|" . encodeURIComponent("$imgResizeURL/w_" . $img["displayWidth"] . "/" . fullURL($srcToUse));
+        $thisSwapItem = encodeURIComponent($srcToUse) . "|" . encodeURIComponent("$imgResizeURL?width=" . $img["displayWidth"] . "&url=" . fullURL($srcToUse));
         array_push($tooLargeList, $thisListItem);
         array_push($experimentSwapList, $thisSwapItem);
     }

--- a/www/experiments/imgs-wasteful.inc
+++ b/www/experiments/imgs-wasteful.inc
@@ -33,7 +33,7 @@ if (count($imgsTooLarge)) {
     }
     
     $rwdImagesDesc = "The broadly-supported <code>picture</code> element and/or the <code>srcset</code> and <code>sizes</code> attributes allow you to offer different file sizes to download for a given image depending on a variety of conditions. <a href=\"https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images\">Read more about Responsive Images on MDN </a>.";
-    
+    $tooLargeImgsDesc = "When images are much larger than they appear in the page, they can increase page weight without noticeably improving quality.";
     $experimentsToAdd =  array(
         (object) [
             'title' => 'Consider implementing responsive image techniques',
@@ -57,7 +57,7 @@ if (count($imgsTooLarge)) {
 
     $assessment[$category]["opportunities"][] = array(
         "title" =>  "Images are larger than necessary for display",
-        "desc" => "When images are much larger than they appear in the page, they can increase page weight without noticeably improving quality.",
+        "desc" => $tooLargeImgsDesc,
         "examples" => array_unique($tooLargeList),
         "experiments" => $experimentsToAdd,
         "good" => false,
@@ -66,7 +66,7 @@ if (count($imgsTooLarge)) {
 } else {
     $assessment[$category]["opportunities"][] = array(
         "title" => "Images are sized appropriately for display",
-        "desc" => "When images are much larger than they appear in the page, they can increase page weight without noticeably improving quality.",
+        "desc" => $tooLargeImgsDesc,
         "examples" => array(),
         "good" => true
     );

--- a/www/experiments/imgs-wasteful.inc
+++ b/www/experiments/imgs-wasteful.inc
@@ -7,7 +7,7 @@ $imgResizeURL = Util::getSetting('imgResizeURL', null);
 function fullURL($url)
 {
     global $requests;
-    if (preg_match('/^(https?\:\/\/)/', $url)) {
+    if (parse_url($url, PHP_URL_SCHEME)) {
         return $url;
     } else {
         return $requests[0]['url'] . $url;

--- a/www/settings/custom_metrics/imgs-too-large.js
+++ b/www/settings/custom_metrics/imgs-too-large.js
@@ -1,0 +1,34 @@
+var imgsTooLarge = [];
+var allImgs = document.querySelectorAll("img");
+var widthTolerance = 0.5;
+for (var i = 0; i < allImgs.length; i++) {
+  var boundingClientRect = allImgs[i].getBoundingClientRect();
+  //getBoundingClientRect returns 0 if the image is hidden (display none or parent display none)
+  //display none isn't enough (only catches if that image is display non, not parent)
+  //so we check offsetParent, but also position fixed (in everyone but ff, position fix makes offsetParent null)
+  let isVisible =
+    window.getComputedStyle(allImgs[i]).display != "none" &&
+    (allImgs[i].offsetParent != null ||
+      window.getComputedStyle(allImgs[i]).position == "fixed");
+  // if display width is less than 50% of the full image natural size
+  if (
+    isVisible &&
+    boundingClientRect.width < allImgs[i].naturalWidth * widthTolerance
+  ) {
+    imgsTooLarge.push({
+      src: allImgs[i].getAttribute("src"),
+      html: allImgs[i].outerHTML,
+      currentSrc: allImgs[i].currentSrc,
+      srcSet: allImgs[i].getAttribute("srcset"),
+      sizes: allImgs[i].getAttribute("sizes"),
+      priority: allImgs[i].getAttribute("fetch-priority"),
+      loading: allImgs[i].getAttribute("loading"),
+      naturalWidth: allImgs[i].naturalWidth,
+      naturalHeight: allImgs[i].naturalHeight,
+      displayWidth: boundingClientRect.width,
+      displayHeight: boundingClientRect.height,
+    });
+  }
+}
+
+return imgsTooLarge;


### PR DESCRIPTION
Note: not ready until we decide on an image API service, which will be set via settings. 
Also: This PR builds upon #2548

This new opportunity detects images with natural widths that are more than twice their display width in the page layout. While it does not go further to determine whether the image is sized well or not across other viewport sizes, it does give an idea of how the images are targeted to the particular environment that was tested.

In addition to detecting images that are more than twice as large as displayed, this PR offers a WebPageTest Pro experiment that will resize these images to the width they will be displayed. Such an experiment can be useful in determining the benefits of implementing responsive image markup and serving multiple image sizes.

In the PR, the particular image service URL set via settings. We'll need to investigate the ideal API and whether or not we use an internal one or a third party service. 