### PR TITLE
Fix double-counting of traceroute tests

### DIFF
--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -84,4 +84,13 @@ final class UtilTest extends TestCase
         $total_runs = Util::getRunCount($runs, $fvonly, $lighthouse, $testtype);
         $this->assertEquals(1, $total_runs);
     }
+    public function testGetRunCountTracerouteTest(): void
+    {
+        $runs = 1;
+        $fvonly = 1;
+        $lighthouse = 0;
+        $testtype = 'traceroute';
+        $total_runs = Util::getRunCount($runs, $fvonly, $lighthouse, $testtype);
+        $this->assertEquals(1, $total_runs);
+    }
 }

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -740,6 +740,10 @@ if (!isset($test)) {
         $test['runs'] = 1;
         $test['fvonly'] = 1;
     }
+    // Force test options when running a traceroute-only test
+    if (isset($test['type']) && $test['type'] === 'traceroute') {
+        $test['fvonly'] = 1;
+    }
 } else {
     // don't inherit some settings from the stored test
     unset($test['id']);


### PR DESCRIPTION
.. by setting "first view only" to true so `Util::getRunCount` doesn't multiply by 2