### PR TITLE
Fixed custom metrics not visible

### DIFF
--- a/www/assets/css/pagestyle2.css
+++ b/www/assets/css/pagestyle2.css
@@ -8988,8 +8988,7 @@ wpt-header .wptheader_nav_menu_section a.banner_lfwp:hover {
 }
 
 .scrollableLine {
-  overflow: scroll;
-  height: 2em;
+  overflow: auto;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
Before:
![image](https://github.com/WPO-Foundation/webpagetest/assets/142893024/3871ab0c-386c-4988-9e90-da056b422070)

After:
<img width="869" alt="image" src="https://github.com/WPO-Foundation/webpagetest/assets/142893024/7a3c0ea3-b556-4f85-b99b-e932147445a9">
