### PR TITLE
Bugfix: added interval to set correct select value after form autocomplete

### DIFF
--- a/www/assets/js/country-list/country-list.js
+++ b/www/assets/js/country-list/country-list.js
@@ -25,12 +25,30 @@
 
       // Fill in subdivisions
       this.fillSubdivision(this.countries[0].code);
-
+      var intervalId = null;
       // Attach listener
       this.countrySelector.addEventListener("change", (e) => {
         const code = e.target.value;
         this.fillSubdivision(code);
+        if (intervalId) {
+          clearInterval(intervalId);
+        }
       });
+      
+      // form automcomplete event doesnt trigger change event 
+      // so we must check for value changes when loading
+      var previousValue = this.countrySelector.value;
+      var self = this;
+
+      intervalId = setInterval(function () {
+        if (previousValue !== self.countrySelector.value) {
+          self.fillSubdivision(self.countrySelector.value);
+          if (intervalId) {
+            clearInterval(intervalId);
+            intervalId = null;
+          }
+        }
+      }, 100);
     }
 
     getSubdivisions(countryCode) {


### PR DESCRIPTION
this change should fix the problem on the country select from the user data form(step-2), where the browser autocomplete is setting the value the user selected previously but is not triggering an event when doing so.

this is a fix where we would check the values on an interval and when a change is detected we manually set the correct states.