### PR TITLE
Disabled autocomplete on country and state select boxes

### DIFF
--- a/www/templates/account/plans/includes/billing-address-form.php
+++ b/www/templates/account/plans/includes/billing-address-form.php
@@ -15,7 +15,7 @@
             </div>
             <div class="form-input state">
                 <label for="state">State</label>
-                <select name="state" data-country-selector="state-selector" required>
+                <select autocomplete="off" name="state" data-country-selector="state-selector" required>
                     <?php foreach ($state_list as $state) : ?>
                         <option value="<?= $state['code'] ?>">
                             <?= $state['name']; ?>
@@ -25,7 +25,7 @@
             </div>
             <div class="form-input country">
                 <label for="country">Country</label>
-                <select name="country" data-country-selector="selector" required>
+                <select autocomplete="off" name="country" data-country-selector="selector" required>
                     <?php foreach ($country_list as $country) : ?>
                         <option value="<?= $country["code"] ?>" <?php ($country["code"] === "US") ? 'selected' : '' ?>>
                             <?= $country["name"]; ?>

--- a/www/templates/account/signup/step-2.php
+++ b/www/templates/account/signup/step-2.php
@@ -39,19 +39,17 @@
                 </div>
                 <div class="form-input state">
                     <label for="state">State</label>
-
-                    <select name="state" data-country-selector="state-selector" required>
+                    <select autocomplete="off" name="state" data-country-selector="state-selector" required>
                         <?php foreach ($state_list as $state) : ?>
                             <option value="<?= $state['code'] ?>">
                                 <?= $state['name']; ?>
                             </option>
                         <?php endforeach; ?>
                     </select>
-
                 </div>
                 <div class="form-input country">
                     <label for="country">Country</label>
-                    <select name="country" data-country-selector="selector" required>
+                    <select autocomplete="off" name="country" data-country-selector="selector" required>
                         <?php foreach ($country_list as $country) : ?>
                             <option value="<?= $country["code"] ?>" <?php ($country["code"] === "US") ? 'selected' : '' ?>>
                                 <?= $country["name"]; ?>


### PR DESCRIPTION
These changes will disable autocomplete on the country and state select boxes. this avoid reaching an inconsistent state when going back and forward.

forms affected:
- Signup Account Details (/signup/2)
- Purchase Summary (/account/plan_summary/)