### PR TITLE
Bugfix: added private form value to test payload

### DIFF
--- a/www/runtest.php
+++ b/www/runtest.php
@@ -223,6 +223,7 @@ if (!isset($test)) {
 
     if ($is_private_api_call || $is_private_web_call) {
         $is_private = 1;
+        $test['private'] = 1;
     }
 
     if (isset($req_carbon_control)) {


### PR DESCRIPTION
small fix, added private value to test payload. this should fix the problem where the private setting is not set on the .ini file