### PR TITLE
Bugfix: contact info is readonly for verified user

### DIFF
--- a/www/templates/account/includes/modals/contact-info.php
+++ b/www/templates/account/includes/modals/contact-info.php
@@ -5,23 +5,23 @@
             <div class="section">
                 <div>
                     <label class="required" for="first-name">First Name</label>
-                    <input type="text" name="first-name" maxlength=32 pattern="<?= $validation_pattern; ?>" value="<?= htmlspecialchars($first_name); ?>" title="Do not use <, >, or &#" required />
+                    <input type="text" name="first-name" maxlength=32 pattern="<?= $validation_pattern; ?>" value="<?= htmlspecialchars($first_name); ?>" title="Do not use <, >, or &#" required <?= $is_verified ? '' :'disabled'; ?> />
                 </div>
             </div>
             <div class="section">
                 <div>
                     <label class="required" for="last-name">Last Name</label>
-                    <input type="text" name="last-name" maxlength=32 pattern="<?= $validation_pattern; ?>" title="Do not use <, >, or &#" value="<?= htmlspecialchars($last_name); ?>" required />
+                    <input type="text" name="last-name" maxlength=32 pattern="<?= $validation_pattern; ?>" title="Do not use <, >, or &#" value="<?= htmlspecialchars($last_name); ?>" required <?= $is_verified ? '' :'disabled'; ?>/>
                 </div>
             </div>
             <div class="section">
                 <label for="company-name">Company Name</label>
-                <input type="text" name="company-name" maxlength=32 pattern="<?= $validation_pattern; ?>" title="Do not use <, >, or &#" value="<?= htmlspecialchars($company_name); ?>" />
+                <input type="text" name="company-name" maxlength=32 pattern="<?= $validation_pattern; ?>" title="Do not use <, >, or &#" value="<?= htmlspecialchars($company_name); ?>" <?= $is_verified ? '' :'disabled'; ?>/>
             </div>
 <?php if ($is_paid) : ?>
             <div class="section">
                 <label for="vat-number">VAT Number</label>
-                <input name="vat-number" type="text" maxlength=32 pattern="<?= $validation_pattern; ?>" title="Please insert a valid VAT number" value="<?= htmlspecialchars($vat_number); ?>" required />
+                <input name="vat-number" type="text" maxlength=32 pattern="<?= $validation_pattern; ?>" title="Please insert a valid VAT number" value="<?= htmlspecialchars($vat_number); ?>" required <?= $is_verified ? '' :'disabled'; ?>/>
             </div>
 <?php endif; ?>
             <div class="section">
@@ -30,10 +30,12 @@
             </div>
             <input type="hidden" name="id" value="<?= $id; ?>" />
             <input type="hidden" name="type" value="contact-info" />
-            <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>" />
-            <div class="save-button">
-                <button type="submit" class="pill-button blue">Save</button>
-            </div>
+            <?php if ($is_verified) : ?>
+                <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>" />
+                <div class="save-button">
+                    <button type="submit" class="pill-button blue">Save</button>
+                </div>
+            <?php endif; ?>
         </div>
     </form>
 </fg-modal>


### PR DESCRIPTION
This should make the inputs on the contact info modals read only and hide the save button for non verified users.

![image](https://github.com/catchpoint/WebPageTest/assets/4400047/389e5d3b-4036-4104-8c6e-5b08f4d35ccc)


