### PR TITLE
fix low-contrast text

### DIFF
--- a/www/assets/css/pagestyle2.css
+++ b/www/assets/css/pagestyle2.css
@@ -7248,7 +7248,7 @@ td {
   font-weight: 500;
   display: block;
   font-size: 0.9em;
-  color: #d580ff;
+  color: #b2bacb;
   padding-top: 0.4em;
 }
 


### PR DESCRIPTION
I copied the shade of grey from the nearby `.feature-callouts p`

## before

<img width="853" alt="Screenshot 2023-12-13 at 8 08 16 PM" src="https://github.com/catchpoint/WebPageTest/assets/51308/86ffa3c5-fb87-4b24-a20d-ec4792385d07">

## after

<img width="1025" alt="Screenshot 2023-12-13 at 8 13 06 PM" src="https://github.com/catchpoint/WebPageTest/assets/51308/ac83e5f0-44c3-4d16-b5ff-7016ab6ecaa6">
