### PR TITLE
Lighthouse treemap button fix

### DIFF
--- a/www/include/lighthouse-page.inc.php
+++ b/www/include/lighthouse-page.inc.php
@@ -77,6 +77,7 @@ if ($lhResults) {
     $treemap = [
         'lhr' => [
             'requestedUrl' => $url,
+            'finalUrl' => $url,
             'audits' => [
                 'script-treemap-data' => [
                     'details' => $lhResults->audits->{'script-treemap-data'}->details


### PR DESCRIPTION
added a missing field `finalUrl`

Treemap was breaking due to missing field and was throwing the error `TypeError: Failed to construct 'URL': Invalid URL`