### PR TITLE
Update Dockerfile-wptagent with git target folder

### DIFF
--- a/docker/local/Dockerfile-wptagent
+++ b/docker/local/Dockerfile-wptagent
@@ -42,7 +42,7 @@ RUN ln -fs /usr/share/zoneinfo/$TIMEZONE /etc/localtime && apt install -y \
     ttf-mscorefonts-installer fonts-noto fonts-roboto fonts-open-sans ffmpeg npm sudo curl xvfb
 
 # Get WPTAgent for dependecies
-RUN git clone -b master https://github.com/catchpoint/WebPageTest.agent.git
+RUN git clone -b master https://github.com/catchpoint/WebPageTest.agent.git /wptagent
 
 ### UPDATE FONT CACHE ###
 RUN fc-cache -f -v


### PR DESCRIPTION
Changed target folder for git clone as it was renamed in previous change. 

**From** https://github.com/WPO-Foundation/wptagent.git **to** https://github.com/catchpoint/WebPageTest.agent.git
This prevented the dockerfile to compile as the root folder to became WebPageTest.agent instead of wptagent.

Root folder is now back to wptagent